### PR TITLE
Fix wrong name for serverSeparator

### DIFF
--- a/pages/Components.md
+++ b/pages/Components.md
@@ -327,7 +327,7 @@ The following components are available:
     
     * ##### `serverSeparator`
     
-        The `serverFooter` specifies a list of custom slots displayed
+        The `serverSeparator` specifies a list of custom slots displayed
          between each pair of two servers.
     
     * ##### `showServers`


### PR DESCRIPTION
Closes https://github.com/CodeCrafter47/BungeeTabListPlus/issues/618