### PR TITLE
display question about bugged icons on ATO wiki

### DIFF
--- a/pages/FAQ.md
+++ b/pages/FAQ.md
@@ -66,10 +66,20 @@ This bug only appears when specific conditions are met:
 * Your Tab list doesn't use all 80 available slots.
 * You don't use a playerSet that displays all players from at least the viewer's server.
 
-This is a limitation of MC and the only fix for it is to either use a `FIXED_SIZE` tab list with `size: 80` or a playerSet that displays all the players from the same server as the viewer.
+This is a limitation of Minecraft and there are currently 2 solutions you can try:
 
 [!]: ifBTLP
 
+- Set the Tab list type to `FIXED_SIZE` with `size` set to 80. This will fill all slots with players causing the bug to not happen.
+- Use a Player set which does include all players from the same server.
+
 See [this question](#how-to-set-that-only-players-on-a-local-server-can-be-seen) for how to make such a playerSet.
+
+[!]: endIF
+
+[!]: ifATO
+
+- Set the Tab list type to `FIXED_SIZE` with `size` set to 80. This will fill all slots with players causing the bug to not happen.
+- Make sure that all players online are displayed somewhere on the tab list.
 
 [!]: endIF

--- a/pages/FAQ.md
+++ b/pages/FAQ.md
@@ -57,6 +57,8 @@ The following steps allow you to create a separate tab list configuration for pl
 Have a look at AdvancedTabOverlay for a Bukkit port of the plugin.
 * <https://www.spigotmc.org/resources/advancedtaboverlay.78905/>
 
+[!]: endIF
+
 ### Random player icons show up in the bottom right/top left of the tab list
 
 This bug only appears when specific conditions are met:
@@ -64,6 +66,10 @@ This bug only appears when specific conditions are met:
 * Your Tab list doesn't use all 80 available slots.
 * You don't use a playerSet that displays all players from at least the viewer's server.
 
-This is a limitation of MC and the only fix for it is to either use a `FIXED_SIZE` tab list with `size: 80` or a playerSet that displays all the players from the same server as the viewer. See [this question](#how-to-set-that-only-players-on-a-local-server-can-be-seen) for how to make such a playerSet.
+This is a limitation of MC and the only fix for it is to either use a `FIXED_SIZE` tab list with `size: 80` or a playerSet that displays all the players from the same server as the viewer.
+
+[!]: ifBTLP
+
+See [this question](#how-to-set-that-only-players-on-a-local-server-can-be-seen) for how to make such a playerSet.
 
 [!]: endIF


### PR DESCRIPTION
The Icon bug also appears on ATO, so the question should be displayed there too.

I changed the question about to keep the last sentence only for the BTLP wiki where the per-server player set is explained.